### PR TITLE
Delete cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,0 @@
-steps:
-# Install dependencies
-- name: node
-  entrypoint: yarn
-  args: ['install']


### PR DESCRIPTION
This placeholder was added for the check to be green. The trigger was removed from the Cloud project, so this should not be needed anymore.